### PR TITLE
Fix double printing of error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ To view the progress of this deployment:
 
     process.exit(0)
   } catch (error) {
-    core.error(error)
     core.setFailed(error.message)
   }
 }


### PR DESCRIPTION
It looks like both `core.error` and `core.setFailed` will annotate the workflow with an error. We only need one annotation. This gets rid of the first annotation pictured below.

<img width="791" alt="Screen Shot 2021-07-21 at 9 14 47 AM" src="https://user-images.githubusercontent.com/9389424/126494894-a304f45b-21df-4fe8-9138-3ffefe84d575.png">
